### PR TITLE
Handle response when http_component is set and include logging of x-fb-debug, x-fb-rev

### DIFF
--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -54,13 +54,13 @@ module Koala
           end
 
           original_api.graph_call("/", args, "post", http_options) do |response|
+            response = JSON.parse(response.body)
             byebug
             raise bad_response if response.nil?
 
-            unless Json.parse(response.body).is_a?(Array)
+            unless response.is_a?(Array)
               raise BadFacebookResponse.new(200, '', "Facebook returned an invalid body")
             end
-
             batch_results += generate_results(response, batch)
           end
         end

--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -70,7 +70,7 @@ module Koala
           self.fb_error_rev = error_info["x-fb-rev"]
 
           error_array = []
-          %w(type code error_subcode message error_user_title error_user_msg fbtrace_id).each do |key|
+          %w(type code error_subcode message error_user_title error_user_msg fbtrace_id x-fb-trace-id x-fb-debug x-fb-rev).each do |key|
             error_array << "#{key}: #{error_info[key]}" if error_info[key]
           end
 

--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -22,6 +22,7 @@ module Koala
                     :fb_error_user_msg,
                     :fb_error_user_title,
                     :fb_error_trace_id,
+                    :fb_error_debug_trace_id,
                     :fb_error_debug,
                     :fb_error_rev
 
@@ -62,13 +63,14 @@ module Koala
           self.fb_error_message = error_info["message"]
           self.fb_error_user_msg = error_info["error_user_msg"]
           self.fb_error_user_title = error_info["error_user_title"]
+          self.fb_error_trace_id = error_info["fbtrace_id"]
 
-          self.fb_error_trace_id = error_info["x-fb-trace-id"]
+          self.fb_error_debug_trace_id = error_info["x-fb-trace-id"]
           self.fb_error_debug = error_info["x-fb-debug"]
           self.fb_error_rev = error_info["x-fb-rev"]
 
           error_array = []
-          %w(type code error_subcode message error_user_title error_user_msg x-fb-trace-id).each do |key|
+          %w(type code error_subcode message error_user_title error_user_msg fbtrace_id).each do |key|
             error_array << "#{key}: #{error_info[key]}" if error_info[key]
           end
 

--- a/spec/cases/error_spec.rb
+++ b/spec/cases/error_spec.rb
@@ -30,7 +30,8 @@ describe Koala::Facebook::APIError do
         'error_subcode' => 'subcode',
         'error_user_msg' => 'error user message',
         'error_user_title' => 'error user title',
-        'x-fb-trace-id' => 'fb trace id',
+        'fbtrace_id' => 'fb trace id',
+        'x-fb-trace-id' => 'x-fb trace id',
         'x-fb-debug' => 'fb debug token',
         'x-fb-rev' => 'fb revision'
       }
@@ -45,6 +46,7 @@ describe Koala::Facebook::APIError do
       :fb_error_user_msg => 'error user message',
       :fb_error_user_title => 'error user title',
       :fb_error_trace_id => 'fb trace id',
+      :fb_error_debug_trace_id => 'x-fb trace id',
       :fb_error_debug => 'fb debug token',
       :fb_error_rev => 'fb revision'
     }.each_pair do |accessor, value|
@@ -54,7 +56,7 @@ describe Koala::Facebook::APIError do
     end
 
     it "sets the error message appropriately" do
-      expect(error.message).to eq("type: type, code: 1, error_subcode: subcode, message: message, error_user_title: error user title, error_user_msg: error user message, x-fb-trace-id: fb trace id [HTTP 400]")
+      expect(error.message).to eq("type: type, code: 1, error_subcode: subcode, message: message, error_user_title: error user title, error_user_msg: error user message, fbtrace_id: fb trace id, x-fb-trace-id: x-fb trace id, x-fb-debug: fb debug token, x-fb-rev: fb revision [HTTP 400]")
     end
   end
 

--- a/spec/cases/graph_error_checker_spec.rb
+++ b/spec/cases/graph_error_checker_spec.rb
@@ -85,7 +85,7 @@ module Koala
               "x-fb-rev" => double("fb rev"),
               "x-fb-trace-id" => double("fb trace id"),
             )
-            expect(error.fb_error_trace_id).to eq(headers["x-fb-trace-id"])
+            expect(error.fb_error_debug_trace_id).to eq(headers["x-fb-trace-id"])
             expect(error.fb_error_debug).to eq(headers["x-fb-debug"])
             expect(error.fb_error_rev).to eq(headers["x-fb-rev"])
           end


### PR DESCRIPTION
Description:

This PR includes changes which will help use the latest koala version without breaking our existing integration.

 Changes included:

- Parsing of response: when `http_component` is set, we receive `Koala::Http_service response` instead of a hash and `generate_results` method handles only JSON response. This affects all batch request. 
- include `x-fb-trace-id` and ` x-fb-debug x-fb-rev ` as part of the error_message returned



[X] My PR has tests and they pass!
